### PR TITLE
Added sidechain connection status update for versions of ProTools ear…

### DIFF
--- a/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
@@ -1074,6 +1074,15 @@ struct AAXClasses
         for (JUCEAlgorithmContext* const* iter = instancesBegin; iter < instancesEnd; ++iter)
         {
             const JUCEAlgorithmContext& i = **iter;
+			
+#if JucePlugin_AcceptsSideChain
+			int32_t sideChainChannel = *i.sideChain;
+			if(sideChainChannel){
+				i.pluginInstance->parameters.getPluginInstance().setInputElementActive(1, true);
+			} else {
+				i.pluginInstance->parameters.getPluginInstance().setInputElementActive(1, false);
+			}
+#endif
 
             i.pluginInstance->parameters.process (i.inputChannels, i.outputChannels,
                                                   *(i.bufferSize), *(i.bypass) != 0,


### PR DESCRIPTION
…lier than 11.1

One of our plugins wasn't detecting sidechain connections in ProTools 10. I checked the AAX documentation and found that connect/disconnect messages aren't sent in PT versions below 11.1. There was another section in the documentation showing this method, so I added it into the callback and it works nicely. 
