### PR TITLE
Fix StickyMidiKeyboardComponent for Windows

### DIFF
--- a/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.cpp
+++ b/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.cpp
@@ -964,7 +964,11 @@ StickyMidiKeyboardComponent::~StickyMidiKeyboardComponent()
     /* Empty */
 }
 
+#ifdef JUCE_WINDOWS
+void StickyMidiKeyboardComponent::mouseUpOnKey(int midiNoteNumber, const MouseEvent& e)
+#else
 void StickyMidiKeyboardComponent::mouseUpOnKey (__unused int midiNoteNumber, const MouseEvent& e)
+#endif
 {
     /** Note: We don't use the midiNoteNumber figured out by the caller by examining
      the mouse event location. Instead, we are interested in what note was under


### PR DESCRIPTION
On Windows MSVC 2013, StickyMidiKeyboardComponent was causing compilation issues due to the use of the __unused flag. I did a quick #ifdef to remove that flag on Windows. It compiles now, but may need further testing (or perhaps a macro to define __unused on Windows).
