### PR TITLE
[Bugfix] Add missing call to detachPreparationStatusObserver() in Pla…

### DIFF
--- a/modules/juce_video/native/juce_mac_Video.h
+++ b/modules/juce_video/native/juce_mac_Video.h
@@ -410,6 +410,8 @@ private:
 
             void preparePlayerItem()
             {
+                detachPreparationStatusObserver();
+
                 playerItem.reset ([[AVPlayerItem alloc] initWithAsset: asset.get()]);
 
                 attachPreparationStatusObserver();


### PR DESCRIPTION
…yerControllerBase<>::PlayerAsyncInitialiser::preparePlayerItem()

In case preparePlayerItem() is called more than once during a PlayerController's lifetime, this avoids playerItemPreparationStatusObserver remaining an observer of already deallocated AVPlayerItems, potentially receiving queued observation callbacks (even if they were queued on the main thread) and crashing