### PR TITLE
Proposed fix for soundradix/pajam#704, fullscreen switch crash

### DIFF
--- a/modules/juce_opengl/native/juce_OpenGL_osx.h
+++ b/modules/juce_opengl/native/juce_OpenGL_osx.h
@@ -66,8 +66,6 @@ public:
         [format release];
 
         viewAttachment = NSViewComponent::attachViewToComponent (component, view);
-
-        updateColourSpace();
     }
 
     ~NativeContext()
@@ -234,15 +232,8 @@ public:
         return numFrames;
     }
 
-    void* getNSColourSpace() { return colourSpace; }
+    void* getNSColourSpace() { return [[[view window] screen] colorSpace]; }
 
-    void* updateColourSpace()
-    {
-        colourSpace = [[[view window] screen] colorSpace];
-        return colourSpace;
-    }
-
-    NSColorSpace* colourSpace = nil;
     NSOpenGLContext* renderContext = nil;
     NSOpenGLView* view = nil;
     ReferenceCountedObjectPtr<ReferenceCountedObject> viewAttachment;

--- a/modules/juce_opengl/opengl/juce_OpenGLContext.cpp
+++ b/modules/juce_opengl/opengl/juce_OpenGLContext.cpp
@@ -159,12 +159,7 @@ public:
     //==============================================================================
     void paint (Graphics&) override
     {
-        bool canTriggerUpdate = false;
-#if JUCE_MAC
-        auto* lastColourSpace = nativeContext->getNSColourSpace();
-        canTriggerUpdate = lastColourSpace != nativeContext->updateColourSpace();
-#endif
-        updateViewportSize (canTriggerUpdate);
+        updateViewportSize (true);
     }
 
     bool invalidateAll() override


### PR DESCRIPTION
My first fix invloved correctly retaining/releasing the colourSpace
member whenever it was changed, so it was never released while we still
had a reference to it.

But then I realized that basically we're always just updating it to be
equal to [[[view window] screen] colorSpace], and it's better not to
have to maintain state if you can.

This does make one change which I don't understand the significance of
-- in paint() we are now always calling updateViewportSize with
canTriggerUpdate = true, instead of only passing canTriggerUpdate when
the colorspace changed.  But I don't see why, if we were allowed to
update when the colorspace changed, why we wouldn't always be allowed to
update.  I don't think there should be a huge performance impact because
updateViewportSize only invalidates when the viewport actually changes.
Please advise.