### PR TITLE
Alternative fix for crash on fullscreen switching

### DIFF
--- a/modules/juce_opengl/native/juce_OpenGL_osx.h
+++ b/modules/juce_opengl/native/juce_OpenGL_osx.h
@@ -77,6 +77,7 @@ public:
         [renderContext setView: nil];
         [view setOpenGLContext: nil];
         [view release];
+        [colourSpace release];
     }
 
     static void createAttribs (NSOpenGLPixelFormatAttribute* attribs, OpenGLVersion version,
@@ -238,7 +239,8 @@ public:
 
     void* updateColourSpace()
     {
-        colourSpace = [[[view window] screen] colorSpace];
+        [colourSpace release];
+        colourSpace = [[[[view window] screen] colorSpace] retain];
         return colourSpace;
     }
 


### PR DESCRIPTION
This correctly maintains the reference count on NativeContext::colourSpace, so that it doesn't become a dangling pointer.

A proposed fix for soundradix/pajam#704.