### PR TITLE
Add flag to suggest context of change for:

### DIFF
--- a/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
@@ -1393,24 +1393,28 @@ namespace AAXClasses
                 SetParameterNormalizedValue (paramID, (double) newValue);
         }
 
-        void audioProcessorChanged (AudioProcessor* processor) override
+        void audioProcessorChanged (AudioProcessor* processor, int flags) override
         {
             ++mNumPlugInChanges;
 
-            auto numParameters = juceParameters.getNumParameters();
-
-            for (int i = 0; i < numParameters; ++i)
+            if (flags & AudioProcessorListener::Flags::parametersUpdate)
             {
-                if (auto* p = mParameterManager.GetParameterByID (getAAXParamIDFromJuceIndex (i)))
-                {
-                    auto newName = juceParameters.getParamForIndex (i)->getName (31);
+                auto numParameters = juceParameters.getNumParameters();
 
-                    if (p->Name() != newName.toRawUTF8())
-                        p->SetName (AAX_CString (newName.toRawUTF8()));
+                for (int i = 0; i < numParameters; ++i)
+                {
+                    if (auto* p = mParameterManager.GetParameterByID (getAAXParamIDFromJuceIndex (i)))
+                    {
+                        auto newName = juceParameters.getParamForIndex (i)->getName (31);
+
+                        if (p->Name() != newName.toRawUTF8())
+                            p->SetName (AAX_CString (newName.toRawUTF8()));
+                    }
                 }
             }
 
-            check (Controller()->SetSignalLatency (processor->getLatencySamples()));
+            if (flags & AudioProcessorListener::Flags::latencyUpdate)
+                check (Controller()->SetSignalLatency (processor->getLatencySamples()));
         }
 
         void audioProcessorParameterChangeGestureBegin (AudioProcessor*, int parameterIndex) override

--- a/modules/juce_audio_plugin_client/AU/juce_AU_Wrapper.mm
+++ b/modules/juce_audio_plugin_client/AU/juce_AU_Wrapper.mm
@@ -1225,16 +1225,24 @@ public:
         sendAUEvent (kAudioUnitEvent_EndParameterChangeGesture, index);
     }
 
-    void audioProcessorChanged (AudioProcessor*) override
+    void audioProcessorChanged (AudioProcessor*, int flags) override
     {
-        PropertyChanged (kAudioUnitProperty_Latency,       kAudioUnitScope_Global, 0);
-        PropertyChanged (kAudioUnitProperty_ParameterList, kAudioUnitScope_Global, 0);
-        PropertyChanged (kAudioUnitProperty_ParameterInfo, kAudioUnitScope_Global, 0);
-        PropertyChanged (kAudioUnitProperty_ClassInfo,     kAudioUnitScope_Global, 0);
+        if (flags & AudioProcessorListener::Flags::latencyUpdate)
+            PropertyChanged (kAudioUnitProperty_Latency, kAudioUnitScope_Global, 0);
 
-        refreshCurrentPreset();
+        if (flags & AudioProcessorListener::Flags::parametersUpdate)
+        {
+            PropertyChanged (kAudioUnitProperty_ParameterList, kAudioUnitScope_Global, 0);
+            PropertyChanged (kAudioUnitProperty_ParameterInfo, kAudioUnitScope_Global, 0);
+        }
 
-        PropertyChanged (kAudioUnitProperty_PresentPreset, kAudioUnitScope_Global, 0);
+        PropertyChanged (kAudioUnitProperty_ClassInfo, kAudioUnitScope_Global, 0);
+
+        if (flags & AudioProcessorListener::Flags::programUpdate)
+        {
+            refreshCurrentPreset();
+            PropertyChanged (kAudioUnitProperty_PresentPreset, kAudioUnitScope_Global, 0);
+        }
     }
 
     //==============================================================================

--- a/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
+++ b/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
@@ -927,7 +927,7 @@ public:
    #endif
 
     //==============================================================================
-    void audioProcessorChanged (AudioProcessor* processor) override
+    void audioProcessorChanged (AudioProcessor* processor, int) override
     {
         ignoreUnused (processor);
 

--- a/modules/juce_audio_plugin_client/RTAS/juce_RTAS_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/RTAS/juce_RTAS_Wrapper.cpp
@@ -855,7 +855,7 @@ public:
         ReleaseControl (index + 2);
     }
 
-    void audioProcessorChanged (AudioProcessor*) override
+    void audioProcessorChanged (AudioProcessor*, int) override
     {
         // xxx is there an RTAS equivalent?
     }

--- a/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
@@ -1629,7 +1629,8 @@ struct VSTPluginInstance     : public AudioPluginInstance,
     void handleAsyncUpdate() override
     {
         // indicates that something about the plugin has changed..
-        updateHostDisplay();
+        // only usage of triggerAsyncUpdate() is by audioMasterUpdateDisplay
+        updateHostDisplay (AudioProcessorListener::Flags::programUpdate);
     }
 
     pointer_sized_int handleCallback (int32 opcode, int32 index, pointer_sized_int value, void* ptr, float opt)

--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
@@ -420,7 +420,7 @@ void AudioProcessor::setLatencySamples (int newLatency)
     if (latencySamples != newLatency)
     {
         latencySamples = newLatency;
-        updateHostDisplay();
+        updateHostDisplay (AudioProcessorListener::Flags::latencyUpdate);
     }
 }
 
@@ -437,11 +437,11 @@ AudioProcessorListener* AudioProcessor::getListenerLocked (int index) const noex
     return listeners[index];
 }
 
-void AudioProcessor::updateHostDisplay()
+void AudioProcessor::updateHostDisplay (const int flags)
 {
     for (int i = listeners.size(); --i >= 0;)
         if (auto l = getListenerLocked (i))
-            l->audioProcessorChanged (this);
+            l->audioProcessorChanged (this, flags);
 }
 
 void AudioProcessor::checkForDuplicateParamID (AudioProcessorParameter* param)

--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.h
@@ -1066,8 +1066,10 @@ public:
 
         It sends a hint to the host that something like the program, number of parameters,
         etc, has changed, and that it should update itself.
+
+        @param flags - context of change. @see AudioProcessorListener::Flags
     */
-    void updateHostDisplay();
+    void updateHostDisplay (int flags = AudioProcessorListener::Flags::any);
 
     //==============================================================================
     /** Adds a parameter to the AudioProcessor.

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorListener.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorListener.h
@@ -61,6 +61,8 @@ public:
     /** Called to indicate that something else in the plugin has changed, like its
         program, number of parameters, etc.
 
+        @param flags - indicate what changed.
+
         IMPORTANT NOTE: This will be called synchronously, and many audio processors will
         call it during their audio callback. This means that not only has your handler code
         got to be completely thread-safe, but it's also got to be VERY fast, and avoid
@@ -68,7 +70,7 @@ public:
         to trigger an AsyncUpdater or ChangeBroadcaster which you can respond to later on the
         message thread.
     */
-    virtual void audioProcessorChanged (AudioProcessor* processor) = 0;
+    virtual void audioProcessorChanged (AudioProcessor* processor, int flags = Flags::any) = 0;
 
     /** Indicates that a parameter change gesture has started.
 
@@ -104,6 +106,23 @@ public:
     */
     virtual void audioProcessorParameterChangeGestureEnd (AudioProcessor* processor,
                                                           int parameterIndex);
+    
+    //==============================================================================
+    /** Flags that represent specific update(s) to be used by audioProcessorChanged */
+    enum Flags
+    {
+        /** No explicit update */
+        any                                     = 0,
+
+        /** Parameter descriptor update. */
+        parametersUpdate                        = 1,
+
+        /** Program/Preset update. */
+        programUpdate                           = 2,
+
+        /** Latency update. */
+        latencyUpdate                           = 4
+    };
 };
 
 } // namespace juce

--- a/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.cpp
+++ b/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.cpp
@@ -74,7 +74,7 @@ private:
             parameterValueHasChanged = 1;
     }
 
-    void audioProcessorChanged (AudioProcessor*) override {}
+    void audioProcessorChanged (AudioProcessor*, int) override {}
 
     //==============================================================================
     void timerCallback() override


### PR DESCRIPTION
AudioProcessor::updateHost() , AudioProcessorListener::audioProcessorChanged().

This avoid calling 'untouched' states which might flag the host wrongfully.

Why?

During QA/testing of our products we've noticed Ableton is disabling automation (for the entire project) for some calls made by the plug-in. 
https://help.ableton.com/hc/en-us/articles/209069409--Re-enable-Automation-keeps-lighting-up
While we can't change our plug-in to comply with all Ableton's considerations (eg. linked parameters). We can do our best to comply with those we are actually not breaking.

It seems to be affecting other JUCEers as well -
https://forum.juce.com/t/automation-still-disabling-itself-in-ableton/41119

The problem is JUCE uses a 'one-fits-all' method to notify changes hoping hosts don't care if you're overshooting.

This PR tries to resolve this at least for setLatency and keep some scoping of 'what-changed?'.