### PR TITLE
Avoid unused variable warnings with jassert in release

### DIFF
--- a/modules/juce_audio_formats/codecs/juce_CoreAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_CoreAudioFormat.cpp
@@ -572,7 +572,7 @@ static AudioFormatID formatForFileType (AudioFileTypeID fileType)
 static void fillAudioStreamBasicDescription (AudioStreamBasicDescription* fmt)
 {
     UInt32 sz = sizeof (AudioStreamBasicDescription);
-    OSStatus e [[maybe_unused]] = AudioFormatGetProperty (kAudioFormatProperty_FormatInfo, 0, nullptr, &sz, fmt);
+    OSStatus e = AudioFormatGetProperty (kAudioFormatProperty_FormatInfo, 0, nullptr, &sz, fmt);
     jassert (e == noErr);
 }
 
@@ -590,7 +590,7 @@ public:
             fmt.mSampleRate = sr;
             fmt.mChannelsPerFrame = numberOfChannels;
             fmt.mFormatID = formatForFileType (fileType);
-            OSStatus e [[maybe_unused]] = AudioFileInitializeWithCallbacks (
+            OSStatus e = AudioFileInitializeWithCallbacks (
                 this,
                 &readCallback,
                 &writeCallback,
@@ -614,7 +614,7 @@ public:
             fmt.mBitsPerChannel = sizeof (float) * 8;
             fmt.mBytesPerFrame = sizeof (float);
             fillAudioStreamBasicDescription (&fmt);
-            OSStatus e [[maybe_unused]] =
+            OSStatus e =
                 ExtAudioFileSetProperty (audioFileRef, kExtAudioFileProperty_ClientDataFormat, sizeof (fmt), &fmt);
             jassert (e == noErr);
         }
@@ -686,7 +686,7 @@ private:
             FileInputStream in (file->getFile());
             jassert (in.openedOk());
             {
-                bool setPositionOK [[maybe_unused]] = in.setPosition (inPosition);
+                bool setPositionOK = in.setPosition (inPosition);
                 jassert (setPositionOK);
             }
             *actualCount = (UInt32) in.read (buffer, (int) requestCount);
@@ -718,9 +718,9 @@ private:
 
         if (auto* out = dynamic_cast<FileOutputStream*> (self->output))
         {
-            bool setPositionOK [[maybe_unused]] = out->setPosition (size);
+            bool setPositionOK = out->setPosition (size);
             jassert (setPositionOK);
-            Result truncatedOK [[maybe_unused]] = out->truncate();
+            Result truncatedOK = out->truncate();
             jassert (truncatedOK);
         }
         return noErr;

--- a/modules/juce_core/maths/juce_MathsFunctions.h
+++ b/modules/juce_core/maths/juce_MathsFunctions.h
@@ -87,6 +87,11 @@ using uint32    = unsigned int;
 #endif
 
 //==============================================================================
+/** Handy function for avoiding unused variables warning. */
+template <typename... Types>
+void ignoreUnused (Types&&...) noexcept {}
+
+//==============================================================================
 // Some indispensable min/max functions
 
 /** Returns the larger of two values. */
@@ -326,11 +331,6 @@ bool approximatelyEqual (Type a, Type b) noexcept
     return std::abs (a - b) <= (std::numeric_limits<Type>::epsilon() * std::max (a, b))
             || std::abs (a - b) < std::numeric_limits<Type>::min();
 }
-
-//==============================================================================
-/** Handy function for avoiding unused variables warning. */
-template <typename... Types>
-void ignoreUnused (Types&&...) noexcept {}
 
 /** Handy function for getting the number of elements in a simple const C array.
     E.g.

--- a/modules/juce_core/system/juce_PlatformDefs.h
+++ b/modules/juce_core/system/juce_PlatformDefs.h
@@ -171,7 +171,7 @@ namespace juce
   #if JUCE_LOG_ASSERTIONS
    #define jassert(expression)      JUCE_BLOCK_WITH_FORCED_SEMICOLON (if (! (expression)) jassertfalse;)
   #else
-   #define jassert(expression)      JUCE_BLOCK_WITH_FORCED_SEMICOLON ( ; )
+   #define jassert(expression)      JUCE_BLOCK_WITH_FORCED_SEMICOLON (juce::ignoreUnused (expression);)
   #endif
 
 #endif


### PR DESCRIPTION
This technique makes `jassert`s not generate extra unused variable warnings in release builds.
Note that it does not actually use the variable, verified via the compiler explorer: https://godbolt.org/z/hEa1nM9oG